### PR TITLE
Support for secret scanning alerts

### DIFF
--- a/jiralib.py
+++ b/jiralib.py
@@ -12,11 +12,11 @@ DELETE_EVENT = "jira:issue_deleted"
 
 
 TITLE_PREFIXES = {
-    'Alert':  '[Code Scanning Alert]:',
-    'Secret': '[Secret Scanning Alert]:'
+    "Alert": "[Code Scanning Alert]:",
+    "Secret": "[Secret Scanning Alert]:",
 }
 
-DESC_TEMPLATE="""
+DESC_TEMPLATE = """
 {long_desc}
 
 {alert_url}
@@ -162,11 +162,8 @@ class JiraProject:
 
         # attach the new state file
         self.jira.attach_file(
-            i.key,
-            repo_id_to_fname(repo_id),
-            util.state_to_json(state)
+            i.key, repo_id_to_fname(repo_id), util.state_to_json(state)
         )
-
 
     def create_issue(
         self,
@@ -177,14 +174,12 @@ class JiraProject:
         alert_type,
         alert_num,
         repo_key,
-        alert_key
+        alert_key,
     ):
         raw = self.j.create_issue(
             project=self.projectkey,
-            summary='{prefix} {short_desc} in {repo}'.format(
-                prefix=TITLE_PREFIXES[alert_type],
-                short_desc=short_desc,
-                repo=repo_id
+            summary="{prefix} {short_desc} in {repo}".format(
+                prefix=TITLE_PREFIXES[alert_type], short_desc=short_desc, repo=repo_id
             ),
             description=DESC_TEMPLATE.format(
                 long_desc=long_desc,
@@ -193,7 +188,7 @@ class JiraProject:
                 alert_type=alert_type,
                 alert_num=alert_num,
                 repo_key=repo_key,
-                alert_key=alert_key
+                alert_key=alert_key,
             ),
             issuetype={"name": "Bug"},
             labels=self.labels,
@@ -203,15 +198,16 @@ class JiraProject:
                 issue_key=raw.key, alert_num=alert_num, repo_id=repo_id
             )
         )
-        logger.info('Created issue {issue_key} for {alert_type} {alert_num} in {repo_id}.'.format(
-            issue_key=raw.key,
-            alert_type=alert_type,
-            alert_num=alert_num,
-            repo_id=repo_id
-        ))
+        logger.info(
+            "Created issue {issue_key} for {alert_type} {alert_num} in {repo_id}.".format(
+                issue_key=raw.key,
+                alert_type=alert_type,
+                alert_num=alert_num,
+                repo_id=repo_id,
+            )
+        )
 
         return JiraIssue(self, raw)
-
 
     def fetch_issues(self, key):
         issue_search = 'project={jira_project} and description ~ "{key}"'.format(
@@ -325,12 +321,12 @@ def parse_alert_info(desc):
         return failed
     repo_id = m.group(1)
 
-    m = re.search('ALERT_TYPE=(.*)$', desc, re.MULTILINE)
+    m = re.search("ALERT_TYPE=(.*)$", desc, re.MULTILINE)
     if m is None:
         alert_type = None
     else:
         alert_type = m.group(1)
-    m = re.search('ALERT_NUMBER=(.*)$', desc, re.MULTILINE)
+    m = re.search("ALERT_NUMBER=(.*)$", desc, re.MULTILINE)
 
     if m is None:
         return failed

--- a/server.py
+++ b/server.py
@@ -54,9 +54,9 @@ def jira_webhook():
     ):
         return jsonify({"code": 403, "error": "Unauthorized"}), 403
 
-    payload = json.loads(request.data.decode('utf-8'))
-    event = payload['webhookEvent']
-    desc = payload['issue']['fields']['description']
+    payload = json.loads(request.data.decode("utf-8"))
+    event = payload["webhookEvent"]
+    desc = payload["issue"]["fields"]["description"]
     repo_id, _, _, _, _ = jiralib.parse_alert_info(desc)
 
     app.logger.debug('Received JIRA webhook for event "{event}"'.format(event=event))

--- a/server.py
+++ b/server.py
@@ -49,7 +49,7 @@ def jira_webhook():
     payload = json.loads(request.data.decode('utf-8'))
     event = payload['webhookEvent']
     desc = payload['issue']['fields']['description']
-    repo_id, alert_id, _, _ = jiralib.parse_alert_info(desc)
+    repo_id, _, _, _, _ = jiralib.parse_alert_info(desc)
 
     app.logger.debug('Received JIRA webhook for event "{event}"'.format(event=event))
 

--- a/server.py
+++ b/server.py
@@ -107,7 +107,7 @@ def github_webhook():
     alert_url = alert.get("html_url")
     alert_num = alert.get("number")
     rule_id = alert.get("rule").get("id")
-    rule_desc = alert.get("rule").get("id")
+    rule_desc = alert.get("rule").get("description")
 
     # TODO: We might want to do the following asynchronously, as it could
     # take time to do a full sync on a repo with many alerts / issues

--- a/sync.py
+++ b/sync.py
@@ -19,54 +19,30 @@ class Sync:
 
     def alert_created(self, repo_id, alert_num):
         a = self.github.getRepository(repo_id).get_alert(alert_num)
-        self.sync(
-            a,
-            self.jira.fetch_issues(a.get_key()),
-            DIRECTION_G2J
-        )
+        self.sync(a, self.jira.fetch_issues(a.get_key()), DIRECTION_G2J)
 
     def alert_changed(self, repo_id, alert_num):
         a = self.github.getRepository(repo_id).get_alert(alert_num)
-        self.sync(
-            a,
-            self.jira.fetch_issues(a.get_key()),
-            DIRECTION_G2J
-        )
+        self.sync(a, self.jira.fetch_issues(a.get_key()), DIRECTION_G2J)
 
     def alert_fixed(self, repo_id, alert_num):
         a = self.github.getRepository(repo_id).get_alert(alert_num)
-        self.sync(
-            a,
-            self.jira.fetch_issues(a.get_key()),
-            DIRECTION_G2J
-        )
+        self.sync(a, self.jira.fetch_issues(a.get_key()), DIRECTION_G2J)
 
     def issue_created(self, desc):
         repo_id, alert_num, _, _, _ = jiralib.parse_alert_info(desc)
         a = self.github.getRepository(repo_id).get_alert(alert_num)
-        self.sync(
-            a,
-            self.jira.fetch_issues(a.get_key()),
-            DIRECTION_J2G
-        )
+        self.sync(a, self.jira.fetch_issues(a.get_key()), DIRECTION_J2G)
 
     def issue_changed(self, desc):
         repo_id, alert_num, _, _, _ = jiralib.parse_alert_info(desc)
         a = self.github.getRepository(repo_id).get_alert(alert_num)
-        self.sync(
-            a,
-            self.jira.fetch_issues(a.get_key()),
-            DIRECTION_J2G
-        )
+        self.sync(a, self.jira.fetch_issues(a.get_key()), DIRECTION_J2G)
 
     def issue_deleted(self, desc):
         repo_id, alert_num, _, _, _ = jiralib.parse_alert_info(desc)
         a = self.github.getRepository(repo_id).get_alert(alert_num)
-        self.sync(
-            a,
-            self.jira.fetch_issues(a.get_key()),
-            DIRECTION_J2G
-        )
+        self.sync(a, self.jira.fetch_issues(a.get_key()), DIRECTION_J2G)
 
     def sync(self, alert, issues, in_direction):
         if alert is None:
@@ -87,7 +63,7 @@ class Sync:
                 alert.get_type(),
                 alert.number(),
                 alert.github_repo.get_key(),
-                alert.get_key()
+                alert.get_key(),
             )
             newissue.adjust_state(alert.get_state())
             return alert.get_state()
@@ -132,10 +108,7 @@ class Sync:
         pairs = {}
 
         # gather alerts
-        for a in itertools.chain(
-            repo.get_secrets(),
-            repo.get_alerts()
-        ):
+        for a in itertools.chain(repo.get_secrets(), repo.get_alerts()):
             pairs[a.get_key()] = (a, [])
 
         # gather issues

--- a/sync.py
+++ b/sync.py
@@ -1,6 +1,7 @@
 import jiralib
 import ghlib
 import logging
+import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -22,52 +23,58 @@ class Sync:
 
 
     def alert_created(self, repo_id, alert_num):
+        a = self.github.getRepository(repo_id).get_alert(alert_num)
         self.sync(
-            self.github.getRepository(repo_id).get_alert(alert_num),
-            self.jira.fetch_issues(repo_id, alert_num),
+            a,
+            self.jira.fetch_issues(a.get_key()),
             DIRECTION_G2J
         )
 
 
     def alert_changed(self, repo_id, alert_num):
+        a = self.github.getRepository(repo_id).get_alert(alert_num)
         self.sync(
-            self.github.getRepository(repo_id).get_alert(alert_num),
-            self.jira.fetch_issues(repo_id, alert_num),
+            a,
+            self.jira.fetch_issues(a.get_key()),
             DIRECTION_G2J
         )
 
 
     def alert_fixed(self, repo_id, alert_num):
+        a = self.github.getRepository(repo_id).get_alert(alert_num)
         self.sync(
-            self.github.getRepository(repo_id).get_alert(alert_num),
-            self.jira.fetch_issues(repo_id, alert_num),
+            a,
+            self.jira.fetch_issues(a.get_key()),
             DIRECTION_G2J
         )
 
 
     def issue_created(self, desc):
-        repo_id, alert_num, _, _ = jiralib.parse_alert_info(desc)
+        repo_id, alert_num, _, _, _ = jiralib.parse_alert_info(desc)
+        a = self.github.getRepository(repo_id).get_alert(alert_num)
         self.sync(
-            self.github.getRepository(repo_id).get_alert(alert_num),
-            self.jira.fetch_issues(repo_id, alert_num),
+            a,
+            self.jira.fetch_issues(a.get_key()),
             DIRECTION_J2G
         )
 
 
     def issue_changed(self, desc):
-        repo_id, alert_num, _, _ = jiralib.parse_alert_info(desc)
+        repo_id, alert_num, _, _, _ = jiralib.parse_alert_info(desc)
+        a = self.github.getRepository(repo_id).get_alert(alert_num)
         self.sync(
-            self.github.getRepository(repo_id).get_alert(alert_num),
-            self.jira.fetch_issues(repo_id, alert_num),
+            a,
+            self.jira.fetch_issues(a.get_key()),
             DIRECTION_J2G
         )
 
 
     def issue_deleted(self, desc):
-        repo_id, alert_num, _, _ = jiralib.parse_alert_info(desc)
+        repo_id, alert_num, _, _, _ = jiralib.parse_alert_info(desc)
+        a = self.github.getRepository(repo_id).get_alert(alert_num)
         self.sync(
-            self.github.getRepository(repo_id).get_alert(alert_num),
-            self.jira.fetch_issues(repo_id, alert_num),
+            a,
+            self.jira.fetch_issues(a.get_key()),
             DIRECTION_J2G
         )
 
@@ -85,10 +92,13 @@ class Sync:
         if len(issues) == 0:
             newissue = self.jira.create_issue(
                 alert.github_repo.repo_id,
-                alert.json['rule']['id'],
-                alert.json['rule']['description'],
-                alert.json['html_url'],
-                alert.number()
+                alert.short_desc(),
+                alert.long_desc(),
+                alert.hyperlink(),
+                alert.get_type(),
+                alert.number(),
+                alert.github_repo.get_key(),
+                alert.get_key()
             )
             newissue.adjust_state(alert.get_state())
             return alert.get_state()
@@ -108,7 +118,7 @@ class Sync:
         else:
             d = self.direction
 
-        if d & DIRECTION_G2J or alert.is_fixed():
+        if d & DIRECTION_G2J or not alert.can_transition():
             # The user treats GitHub as the source of truth.
             # Also, if the alert to be synchronized is already "fixed"
             # then even if the user treats JIRA as the source of truth,
@@ -127,19 +137,23 @@ class Sync:
             repo_id=repo_id
         ))
 
+        repo = self.github.getRepository(repo_id)
         states = {} if states is None else states
         pairs = {}
 
         # gather alerts
-        for a in self.github.getRepository(repo_id).get_alerts():
-            pairs[a.number()] = (a, [])
+        for a in itertools.chain(
+            repo.get_secrets(),
+            repo.get_alerts()
+        ):
+            pairs[a.get_key()] = (a, [])
 
         # gather issues
-        for i in self.jira.fetch_issues(repo_id):
-            _, anum, _, _ = i.get_alert_info()
-            if not anum in pairs:
-                pairs[anum] = (None, [])
-            pairs[anum][1].append(i)
+        for i in self.jira.fetch_issues(repo.get_key()):
+            _, _, _, alert_key, _ = i.get_alert_info()
+            if not alert_key in pairs:
+                pairs[alert_key] = (None, [])
+            pairs[alert_key][1].append(i)
 
         # remove unused states
         for k in list(states.keys()):
@@ -147,8 +161,8 @@ class Sync:
                 del states[k]
 
         # perform sync
-        for anum, (alert, issues) in pairs.items():
-            past_state = states.get(anum, None)
+        for akey, (alert, issues) in pairs.items():
+            past_state = states.get(akey, None)
             if alert is None or alert.get_state() != past_state:
                 d = DIRECTION_G2J
             else:
@@ -157,6 +171,6 @@ class Sync:
             new_state = self.sync(alert, issues, d)
 
             if new_state is None:
-                states.pop(anum, None)
+                states.pop(akey, None)
             else:
-                states[anum] = new_state
+                states[akey] = new_state

--- a/util.py
+++ b/util.py
@@ -9,19 +9,12 @@ def state_from_json(s):
     j = json.loads(s)
     if not "version" in j:
         return {}
-    return j['states']
+    return j["states"]
 
 
 def state_to_json(state):
-    final = {
-        'version': 2,
-        'states': state
-    }
-    return json.dumps(
-        final,
-        indent=2,
-        sort_keys=True
-    )
+    final = {"version": 2, "states": state}
+    return json.dumps(final, indent=2, sort_keys=True)
 
 
 def state_from_file(fpath):

--- a/util.py
+++ b/util.py
@@ -6,16 +6,19 @@ REQUEST_TIMEOUT = 10
 
 
 def state_from_json(s):
-    # convert string keys into int keys
-    # this is necessary because JSON doesn't allow
-    # int keys and json.dump() automatically converts
-    # int keys into string keys.
-    return {int(k): v for k, v in json.loads(s).items()}
+    j = json.loads(s)
+    if not "version" in j:
+        return {}
+    return j['states']
 
 
 def state_to_json(state):
+    final = {
+        'version': 2,
+        'states': state
+    }
     return json.dumps(
-        state,
+        final,
         indent=2,
         sort_keys=True
     )
@@ -37,10 +40,6 @@ def make_key(s):
     sha_1 = hashlib.sha1()
     sha_1.update(s.encode('utf-8'))
     return sha_1.hexdigest()
-
-
-def make_alert_key(repo_id, alert_num):
-    return make_key(repo_id + '/' + str(alert_num))
 
 
 def json_accept_header():


### PR DESCRIPTION
This PR makes the action also synchronize secret scanning alerts.

Note that the secret scanning api only allows fetching secret alerts from private repositories. For public repositories, we just assume an empty result list.

To achieve this, I had to refactor parts of `ghlib.py` and change the format of the state files (files with the old format will be automatically converted). I took some care to not disturb existing synchronization projects, but would be happy to hear about cases were this PR impacts existing projects negatively.

I'll give this a bit more testing, but wanted to put it out here for initial thoughts.

@cmboling