### PR TITLE
Remove state parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,4 @@ runs:
         --jira-labels "${{ inputs.jira_labels }}" \
         --direction "${{ inputs.sync_direction }}" \
         --issue-end-state "${{ inputs.issue_end_state }}" \
-        --issue-reopen-state "${{ inputs.issue_reopen_state }}" \
-        --state-issue -
+        --issue-reopen-state "${{ inputs.issue_reopen_state }}"


### PR DESCRIPTION
You may have gotten a 403 when fetching for secret scanning alerts; please define an access token with the security_events scope, as defined here in our GH API docs: https://docs.github.com/en/rest/reference/secret-scanning#list-secret-scanning-alerts-for-a-repository

This PR is the beginning of low priority work to remove any references to keep state in a Jira issue: https://github.com/github/ghas-jira-integration/issues/18

For now this will have to be merged asap so that existing workflows can continue to sync code scanning and secret scanning alerts. Apologies for the small mistakes!