### PR TITLE
Fix log injection

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8,11 +8,13 @@ import util
 from sync import Sync, DIRECTION_G2J, DIRECTION_J2G, DIRECTION_BOTH
 import logging
 import server
+import anticrlf
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)
 
 handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(anticrlf.LogFormatter("%(levelname)s:%(name)s:%(message)s"))
 handler.setLevel(logging.DEBUG)
 root.addHandler(handler)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask~=2.0.0
 requests~=2.26.0
 jira~=3.0.0
+logging-formatter-anticrlf==1.2


### PR DESCRIPTION
Fixed a log injection vulnerability caused by incorrect use of log output.

Reference: https://www.srccodes.com/log-forging-by-crlf-log-injection-owasp-security-vulnerability-attacks-crlf/