### PR TITLE
Tool name in description

### DIFF
--- a/ghlib.py
+++ b/ghlib.py
@@ -296,6 +296,9 @@ class Alert(AlertBase):
     def short_desc(self):
         return self.json["rule"]["id"]
 
+    def tool_name(self):
+        return self.json["tool"]["name"]
+
     def get_key(self):
         return util.make_key(self.github_repo.repo_id + "/" + str(self.number()))
 

--- a/jiralib.py
+++ b/jiralib.py
@@ -176,7 +176,7 @@ class JiraProject:
         alert_num,
         repo_key,
         alert_key,
-        tool_name,
+        tool_name
     ):
         raw = self.j.create_issue(
             project=self.projectkey,
@@ -341,11 +341,12 @@ def parse_alert_info(desc):
     m = re.search("ALERT_KEY=(.*)$", desc, re.MULTILINE)
     if m is None:
         return failed
-    alert_key = m.group(1)
-    if m is None:
-        return failed
     tool_name = m.group(1)
     m = re.search("TOOL_NAME=(.*)$", desc, re.MULTILINE)
+    if m is None:
+        return failed
+    alert_key = m.group(1)
+
 
     return repo_id, alert_num, repo_key, alert_key, alert_type, tool_name
 

--- a/jiralib.py
+++ b/jiralib.py
@@ -29,6 +29,7 @@ ALERT_TYPE={alert_type}
 ALERT_NUMBER={alert_num}
 REPOSITORY_KEY={repo_key}
 ALERT_KEY={alert_key}
+TOOL_NAME={tool_name}
 """
 
 
@@ -175,6 +176,7 @@ class JiraProject:
         alert_num,
         repo_key,
         alert_key,
+        tool_name,
     ):
         raw = self.j.create_issue(
             project=self.projectkey,
@@ -189,6 +191,7 @@ class JiraProject:
                 alert_num=alert_num,
                 repo_key=repo_key,
                 alert_key=alert_key,
+                tool_name=tool_name,
             ),
             issuetype={"name": "Bug"},
             labels=self.labels,
@@ -204,6 +207,7 @@ class JiraProject:
                 alert_type=alert_type,
                 alert_num=alert_num,
                 repo_id=repo_id,
+                tool_name=tool_name
             )
         )
 
@@ -314,7 +318,7 @@ def parse_alert_info(desc):
     them as a tuple. If parsing fails for one of the fields,
     return a tuple of None's.
     """
-    failed = None, None, None, None
+    failed = None, None, None, None, None
     m = re.search("REPOSITORY_NAME=(.*)$", desc, re.MULTILINE)
     if m is None:
         return failed
@@ -338,8 +342,12 @@ def parse_alert_info(desc):
     if m is None:
         return failed
     alert_key = m.group(1)
+    if m is None:
+        return failed
+    tool_name = m.group(1)
+    m = re.search("TOOL_NAME=(.*)$", desc, re.MULTILINE)
 
-    return repo_id, alert_num, repo_key, alert_key, alert_type
+    return repo_id, alert_num, repo_key, alert_key, alert_type, tool_name
 
 
 def repo_id_to_fname(repo_id):

--- a/sync.py
+++ b/sync.py
@@ -63,6 +63,7 @@ class Sync:
                 alert.number(),
                 alert.github_repo.get_key(),
                 alert.get_key(),
+                alert.tool_name(),
             )
             newissue.adjust_state(alert.get_state())
             return alert.get_state()


### PR DESCRIPTION
Because multiple tools can be used to report to Code Scanning Alerts, I wanted a way to identify which one has been used while being added to Jira.
This feature adds TOOL_NAME= in Jira's description field.
It gathers this information from each ["tool"]["name"] GitHub alert properties.
ie: TOOL_NAME=ZAProxy, TOOL_NAME=CodeQL, etc.
