### PR TITLE
Remove `requirements.txt`, use `Pipfile` instead

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,6 +32,3 @@ jobs:
       - name: run flake8 linter
         # Ignore linting errors that the black formatter is opiniated about
         run: pipenv run flake8 --ignore E501,W503 .
-
-      - name: run bandit security scan
-        run: pipenv run bandit -r .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,15 +20,18 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install pipenv
+        run: pip install pipenv
+
       - name: install dependencies
-        run: pip install -r requirements.txt
+        run: pipenv install --dev
 
       - name: run black formatter
-        run: black --check .
+        run: pipenv run black --check .
 
       - name: run flake8 linter
         # Ignore linting errors that the black formatter is opiniated about
-        run: flake8 --ignore E501,W503 .
+        run: pipenv run flake8 --ignore E501,W503 .
 
       - name: run bandit security scan
-        run: bandit -r .
+        run: pipenv run bandit -r .

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,6 @@ jira = "~=3.0.0"
 logging-formatter-anticrlf = "~=1.2.1"
 
 [dev-packages]
-bandit = "~=1.7.9"
 black = "~=24.4.2"
 flake8 = "~=7.1.0"
 

--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,10 @@ requests = "~=2.32.3"
 jira = "~=3.0.0"
 logging-formatter-anticrlf = "~=1.2.1"
 
+[dev-packages]
+bandit = "~=1.7.9"
+black = "~=24.4.2"
+flake8 = "~=7.1.0"
+
 [requires]
 python_version = "3"

--- a/action.yml
+++ b/action.yml
@@ -52,15 +52,11 @@ runs:
       INPUTS_ISSUE_END_STATE: ${{ inputs.issue_end_state }}
       INPUTS_ISSUE_REOPEN_STATE: ${{ inputs.issue_reopen_state }}
     run: |
-      # Install pipenv to a temporary directory
-      # We use a temporary directory because the action didn't previously have a requirement for
-      # pipenv to be installed, and we don't want to pollute the user's existing pip installations.
-      pip3 install pipenv --target "$RUNNER_TEMP/pip"
-      # Run pipenv from the temporary directory
-      $RUNNER_TEMP/pip/pipenv install
+      pip3 install pipenv
+      pipenv install
       REPOSITORY_NAME="$(echo "$GITHUB_REPOSITORY" | cut -d/ -f 2)"
       # Run pipenv from the temporary directory
-      $RUNNER_TEMP/pip/pipenv run ./gh2jira sync \
+      pipenv run ./gh2jira sync \
         --gh-url "$GITHUB_API_URL" \
         --gh-token "$INPUTS_GITHUB_TOKEN" \
         --gh-org "$GITHUB_REPOSITORY_OWNER" \

--- a/action.yml
+++ b/action.yml
@@ -52,9 +52,15 @@ runs:
       INPUTS_ISSUE_END_STATE: ${{ inputs.issue_end_state }}
       INPUTS_ISSUE_REOPEN_STATE: ${{ inputs.issue_reopen_state }}
     run: |
-      pip3 install -r requirements.txt
+      # Install pipenv to a temporary directory
+      # We use a temporary directory because the action didn't previously have a requirement for
+      # pipenv to be installed, and we don't want to pollute the user's existing pip installations.
+      pip3 install pipenv --target "$RUNNER_TEMP/pip"
+      # Run pipenv from the temporary directory
+      $RUNNER_TEMP/pip/pipenv install
       REPOSITORY_NAME="$(echo "$GITHUB_REPOSITORY" | cut -d/ -f 2)"
-      ./gh2jira sync \
+      # Run pipenv from the temporary directory
+      $RUNNER_TEMP/pip/pipenv run ./gh2jira sync \
         --gh-url "$GITHUB_API_URL" \
         --gh-token "$INPUTS_GITHUB_TOKEN" \
         --gh-org "$GITHUB_REPOSITORY_OWNER" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-bandit~=1.7.9
-black~=24.4.2
-flake8~=7.1.0
-flask~=2.3.0
-jira~=3.0.0
-logging-formatter-anticrlf==1.2.1
-requests~=2.26.0


### PR DESCRIPTION
We currently have both a `Pipfile` and `requirements.txt` file in this repository, which specify different dependency versions. This PR standardises on the `Pipfile` and `pipenv` to give a single source of truth for the dependencies for the project. The `Pipfile` was chosen as this is already the recommended way of running the integration specified in the documentation.