### PR TITLE
Potential fix for code scanning alert no. 88: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,7 @@
 ---
 name: python
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/github/ghas-jira-integration/security/code-scanning/88](https://github.com/github/ghas-jira-integration/security/code-scanning/88)

The optimal way to fix this issue is to explicitly add a `permissions` key with the least required privilege. Since this workflow does not seem to require any `write` or elevated permissions (it installs dependencies and runs formatters/linters only), the minimal privilege necessary would be `contents: read`. This should be added either at the workflow root level (just after the `name:` and before `on:`) or at the job level. Conventionally, it's better to set it at the root to cover all jobs by default. The changes should be made at the top of `.github/workflows/python.yml` after the `name:` line and before the `on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
